### PR TITLE
Changed trim of item name in shop to 80 chars (from 40)

### DIFF
--- a/src/gameClasses/components/ShopComponent.js
+++ b/src/gameClasses/components/ShopComponent.js
@@ -938,7 +938,7 @@ var ShopComponent = IgeEntity.extend({
 						});
 
 						var itemName = "<div class='mx-2 mt-2 mb-0 no-selection' style='line-height:0.7 !important;'><small>";
-						itemName += item.name && typeof item.name === 'string' && item.name.substring(0, 40) || item.name;
+						itemName += item.name && typeof item.name === 'string' && item.name.substring(0, 80) || item.name;
 						itemName += "</small></div>";
 
 						var combine = $("<div/>", {


### PR DESCRIPTION
This might be a problem for users with 80 character names. Maybe consider adding css wrapping classes in the future. Needed for items with html names were real len is short but html len is long