### PR TITLE
Add function 'roundToNearest'; parameters: 'num1', 'num2'

### DIFF
--- a/src/gameClasses/components/script/VariableComponent.js
+++ b/src/gameClasses/components/script/VariableComponent.js
@@ -1104,6 +1104,12 @@ var VariableComponent = IgeEntity.extend({
 					var value = self.getValue(text.value, vars);
 					if (!isNaN(value))
 						return Math.floor(value);
+					break;	
+				
+				case 'roundToNearest': // round num1 to the nearest num2
+					var roundNum = self.getValue(text.num1, vars);
+					var toNum = self.getValue(text.num2, vars);
+					returnValue = parseInt(roundNum / toNum + 0.5) * toNum
 					break;
 
 				case 'getEntireMapRegion':


### PR DESCRIPTION
Add a function roundToNearest which rounds num1 to the nearest num2. For example, if you do (round 90 to the nearest 100) it will return 100. This would be a very useful function for creators because instead of using (calculate (floor of (calculate(calculate(x / y) + 0.5) ) * y)) they can just do (round x to the nearest y).