### PR TITLE
Add node.js CI / CD to verify builds.

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,29 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build:git

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build/
 heapdump/
 log.log
 typings/**

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "server:remote": "cross-env ENV=standalone-remote node server/ige.js -g ./src",
     "build": "cross-env TEST=true node server/ige.js -deploy ./src -to ../be/assets",
     "build:gs": "cross-env TEST=true node server/ige.js -deploy ./src -to ../../be/assets",
+    "build:git": "cross-env TEST=true node server/ige.js -deploy ./src -to ./build",
     "debug": "cross-env ENV=standalone node --inspect server/ige.js -g ./src"
   },
   "dependencies": {


### PR DESCRIPTION
Allows GitHub to verify that a commit is not a breaking change by running clean builds.

This adds a configuration file for GitHub Actions, as well as a package script `npm run build:git` which is used to build for GitHub.