### PR TITLE
Add dependabot support.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot is an application that allows for the upgrading of packages automatically, through pull requests created automatically.
These can be merged at any time by someone with write access.

Keep in mind, however, that compatibility may not be fully fluent with all pull requests (i.e. major version changes, these may not be backwards compatible as specified by `semantic versioning`).

Dependabot is currently configured to pull packages from NPM and open up to 10 pull requests of package upgrades `daily`. This can be changed in accordance with its configuration.